### PR TITLE
Separate Intent and Update Versions

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -34,6 +34,7 @@ captures/
 
 # Intellij
 *.iml
+.idea/
 .idea/workspace.xml
 
 # Keystore files

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -1,13 +1,13 @@
 apply plugin: 'com.android.application'
 
 android {
-    compileSdkVersion 26
-    buildToolsVersion '26.0.2'
+    compileSdkVersion 27
+    buildToolsVersion '27.0.3'
 
     defaultConfig {
         applicationId "devliving.online.mvbarcodereadersample"
         minSdkVersion 15
-        targetSdkVersion 26
+        targetSdkVersion 27
         versionCode 4
         versionName "1.1.1"
     }
@@ -22,10 +22,10 @@ android {
 dependencies {
     compile fileTree(include: ['*.jar'], dir: 'libs')
     testCompile 'junit:junit:4.12'
-    compile 'com.android.support:appcompat-v7:26.1.0'
-    compile 'com.google.android.gms:play-services-basement:11.8.0'
-    compile 'com.google.android.gms:play-services-vision:11.8.0'
-    compile 'com.android.support:design:26.1.0'
-    compile 'com.android.support:support-annotations:27.0.2'
+    compile 'com.android.support:appcompat-v7:27.1.1'
+    compile 'com.google.android.gms:play-services-basement:15.0.0'
+    compile 'com.google.android.gms:play-services-vision:15.0.0'
+    compile 'com.android.support:design:27.1.1'
+    compile 'com.android.support:support-annotations:27.1.1'
     compile project(':mvbarcodereader')
 }

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -20,12 +20,12 @@ android {
 }
 
 dependencies {
-    compile fileTree(include: ['*.jar'], dir: 'libs')
-    testCompile 'junit:junit:4.12'
-    compile 'com.android.support:appcompat-v7:27.1.1'
-    compile 'com.google.android.gms:play-services-basement:15.0.0'
-    compile 'com.google.android.gms:play-services-vision:15.0.0'
-    compile 'com.android.support:design:27.1.1'
-    compile 'com.android.support:support-annotations:27.1.1'
-    compile project(':mvbarcodereader')
+    implementation fileTree(include: ['*.jar'], dir: 'libs')
+    testImplementation 'junit:junit:4.12'
+    implementation 'com.android.support:appcompat-v7:27.1.1'
+    implementation 'com.google.android.gms:play-services-basement:15.0.1'
+    implementation 'com.google.android.gms:play-services-vision:15.0.1'
+    implementation 'com.android.support:design:27.1.1'
+    implementation 'com.android.support:support-annotations:27.1.1'
+    implementation project(':mvbarcodereader')
 }

--- a/build.gradle
+++ b/build.gradle
@@ -7,11 +7,6 @@ buildscript {
     }
     dependencies {
         classpath 'com.android.tools.build:gradle:3.1.2'
-
-        classpath 'com.github.dcendents:android-maven-gradle-plugin:1.4.1'
-        classpath 'com.jfrog.bintray.gradle:gradle-bintray-plugin:1.3.1'
-        // NOTE: Do not place your application dependencies here; they belong
-        // in the individual module build.gradle files
     }
 }
 

--- a/build.gradle
+++ b/build.gradle
@@ -7,6 +7,11 @@ buildscript {
     }
     dependencies {
         classpath 'com.android.tools.build:gradle:3.1.2'
+
+        classpath 'com.github.dcendents:android-maven-gradle-plugin:1.4.1'
+        classpath 'com.jfrog.bintray.gradle:gradle-bintray-plugin:1.1'
+        // NOTE: Do not place your application dependencies here; they belong
+        // in the individual module build.gradle files
     }
 }
 

--- a/build.gradle
+++ b/build.gradle
@@ -6,10 +6,10 @@ buildscript {
         google()
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:3.0.1'
+        classpath 'com.android.tools.build:gradle:3.1.2'
 
         classpath 'com.github.dcendents:android-maven-gradle-plugin:1.4.1'
-        classpath 'com.jfrog.bintray.gradle:gradle-bintray-plugin:1.1'
+        classpath 'com.jfrog.bintray.gradle:gradle-bintray-plugin:1.3.1'
         // NOTE: Do not place your application dependencies here; they belong
         // in the individual module build.gradle files
     }

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
-#Mon Dec 04 14:52:49 BDT 2017
+#Wed May 02 16:05:17 EDT 2018
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-4.1-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-4.4-all.zip

--- a/mvbarcodereader/build.gradle
+++ b/mvbarcodereader/build.gradle
@@ -1,5 +1,6 @@
 apply plugin: 'com.android.library'
-apply plugin: 'maven'
+apply plugin: 'com.github.dcendents.android-maven'
+apply plugin: "com.jfrog.bintray"
 
 version = "1.1.3"
 
@@ -30,4 +31,92 @@ dependencies {
     compileOnly 'com.google.android.gms:play-services-vision:15.0.0'
     compileOnly 'com.android.support:design:27.1.1'
     compileOnly 'com.android.support:support-annotations:27.1.1'
+}
+
+def siteUrl = "https://github.com/iamMehedi/MVBarcodeReader"
+def gitUrl = "https://github.com/iamMehedi/MVBarcodeReader.git"
+
+group = "online.devliving"
+
+install {
+    repositories.mavenInstaller {
+        // This generates POM.xml with proper parameters
+        pom {
+            project {
+                packaging 'aar'
+
+                // Add your description here
+                name 'online.devliving:mvbarcodereader'
+                description = 'A Barcode Scanning Library for Android'
+                url siteUrl
+
+                // Set your license
+                licenses {
+                    license {
+                        name 'The Apache Software License, Version 2.0'
+                        url 'http://www.apache.org/licenses/LICENSE-2.0.txt'
+                    }
+                }
+                developers {
+                    developer {
+                        id 'im_mehedi'
+                        name 'Mehedi Hasan Khan'
+                        email 'mehedi.mailing@gmail.com'
+                    }
+                }
+                scm {
+                    connection gitUrl
+                    developerConnection gitUrl
+                    url siteUrl
+                }
+            }
+        }
+    }
+}
+
+task sourcesJar(type: Jar) {
+    from android.sourceSets.main.java.srcDirs
+    classifier = 'sources'
+}
+
+task javadoc(type: Javadoc) {
+    source = android.sourceSets.main.java.srcDirs
+    classpath += project.files(android.getBootClasspath().join(File.pathSeparator))
+    failOnError false
+}
+
+task javadocJar(type: Jar, dependsOn: javadoc) {
+    classifier = 'javadoc'
+    from javadoc.destinationDir
+}
+artifacts {
+    archives javadocJar
+    archives sourcesJar
+}
+
+Properties properties = new Properties()
+properties.load(project.rootProject.file('local.properties').newDataInputStream())
+
+// https://github.com/bintray/gradle-bintray-plugin
+bintray {
+    user = properties.getProperty("bintray.user")
+    key = properties.getProperty("bintray.apikey")
+
+    configurations = ['archives']
+    pkg {
+        repo = "MVBarcodeReader"
+        // it is the name that appears in bintray when logged
+        name = "online.devliving:mvbarcodereader"
+        websiteUrl = siteUrl
+        vcsUrl = gitUrl
+        licenses = ["Apache-2.0"]
+        publish = true
+        version {
+            gpg {
+                sign = true //Determines whether to GPG sign the files. The default is false
+                passphrase = properties.getProperty("bintray.gpg.password")
+                //Optional. The passphrase for GPG signing'
+            }
+        }
+    }
 }

--- a/mvbarcodereader/build.gradle
+++ b/mvbarcodereader/build.gradle
@@ -23,14 +23,14 @@ android {
 }
 
 dependencies {
-    implementation fileTree(dir: 'libs', include: ['*.jar'])
-    testImplementation 'junit:junit:4.12'
-    implementation 'com.android.support:appcompat-v7:27.1.1'
-    implementation 'online.devliving:mobilevision-pipeline:1.0.7'
-    implementation 'com.google.android.gms:play-services-basement:15.0.0'
-    implementation 'com.google.android.gms:play-services-vision:15.0.0'
-    implementation 'com.android.support:design:27.1.1'
-    implementation 'com.android.support:support-annotations:27.1.1'
+    compile fileTree(dir: 'libs', include: ['*.jar'])
+    testCompile 'junit:junit:4.12'
+    compile 'com.android.support:appcompat-v7:27.1.1'
+    compile 'online.devliving:mobilevision-pipeline:1.0.7'
+    compile 'com.google.android.gms:play-services-basement:15.0.0'
+    compile 'com.google.android.gms:play-services-vision:15.0.0'
+    compile 'com.android.support:design:27.1.1'
+    compile 'com.android.support:support-annotations:27.1.1'
 }
 
 def siteUrl = "https://github.com/iamMehedi/MVBarcodeReader"

--- a/mvbarcodereader/build.gradle
+++ b/mvbarcodereader/build.gradle
@@ -1,6 +1,4 @@
 apply plugin: 'com.android.library'
-apply plugin: 'com.github.dcendents.android-maven'
-apply plugin: "com.jfrog.bintray"
 
 version = "1.1.3"
 
@@ -23,100 +21,12 @@ android {
 }
 
 dependencies {
-    compile fileTree(dir: 'libs', include: ['*.jar'])
-    testCompile 'junit:junit:4.12'
-    compile 'com.android.support:appcompat-v7:27.1.1'
-    compile 'online.devliving:mobilevision-pipeline:1.0.7'
-    compile 'com.google.android.gms:play-services-basement:15.0.0'
-    compile 'com.google.android.gms:play-services-vision:15.0.0'
-    compile 'com.android.support:design:27.1.1'
-    compile 'com.android.support:support-annotations:27.1.1'
-}
-
-def siteUrl = "https://github.com/iamMehedi/MVBarcodeReader"
-def gitUrl = "https://github.com/iamMehedi/MVBarcodeReader.git"
-
-group = "online.devliving"
-
-install {
-    repositories.mavenInstaller {
-        // This generates POM.xml with proper parameters
-        pom {
-            project {
-                packaging 'aar'
-
-                // Add your description here
-                name 'online.devliving:mvbarcodereader'
-                description = 'A Barcode Scanning Library for Android'
-                url siteUrl
-
-                // Set your license
-                licenses {
-                    license {
-                        name 'The Apache Software License, Version 2.0'
-                        url 'http://www.apache.org/licenses/LICENSE-2.0.txt'
-                    }
-                }
-                developers {
-                    developer {
-                        id 'im_mehedi'
-                        name 'Mehedi Hasan Khan'
-                        email 'mehedi.mailing@gmail.com'
-                    }
-                }
-                scm {
-                    connection gitUrl
-                    developerConnection gitUrl
-                    url siteUrl
-                }
-            }
-        }
-    }
-}
-
-task sourcesJar(type: Jar) {
-    from android.sourceSets.main.java.srcDirs
-    classifier = 'sources'
-}
-
-task javadoc(type: Javadoc) {
-    source = android.sourceSets.main.java.srcDirs
-    classpath += project.files(android.getBootClasspath().join(File.pathSeparator))
-    failOnError false
-}
-
-task javadocJar(type: Jar, dependsOn: javadoc) {
-    classifier = 'javadoc'
-    from javadoc.destinationDir
-}
-artifacts {
-    archives javadocJar
-    archives sourcesJar
-}
-
-Properties properties = new Properties()
-properties.load(project.rootProject.file('local.properties').newDataInputStream())
-
-// https://github.com/bintray/gradle-bintray-plugin
-bintray {
-    user = properties.getProperty("bintray.user")
-    key = properties.getProperty("bintray.apikey")
-
-    configurations = ['archives']
-    pkg {
-        repo = "MVBarcodeReader"
-        // it is the name that appears in bintray when logged
-        name = "online.devliving:mvbarcodereader"
-        websiteUrl = siteUrl
-        vcsUrl = gitUrl
-        licenses = ["Apache-2.0"]
-        publish = true
-        version {
-            gpg {
-                sign = true //Determines whether to GPG sign the files. The default is false
-                passphrase = properties.getProperty("bintray.gpg.password")
-                //Optional. The passphrase for GPG signing'
-            }
-        }
-    }
+    implementation fileTree(dir: 'libs', include: ['*.jar'])
+    testImplementation 'junit:junit:4.12'
+    implementation 'com.android.support:appcompat-v7:27.1.1'
+    implementation 'online.devliving:mobilevision-pipeline:1.0.7'
+    implementation 'com.google.android.gms:play-services-basement:15.0.0'
+    implementation 'com.google.android.gms:play-services-vision:15.0.0'
+    implementation 'com.android.support:design:27.1.1'
+    implementation 'com.android.support:support-annotations:27.1.1'
 }

--- a/mvbarcodereader/build.gradle
+++ b/mvbarcodereader/build.gradle
@@ -23,14 +23,14 @@ android {
 }
 
 dependencies {
-    compile fileTree(dir: 'libs', include: ['*.jar'])
-    testCompile 'junit:junit:4.12'
-    compile 'com.android.support:appcompat-v7:26.1.0'
-    compile 'online.devliving:mobilevision-pipeline:1.0.7'
-    provided 'com.google.android.gms:play-services-basement:11.8.0'
-    provided 'com.google.android.gms:play-services-vision:11.8.0'
-    provided 'com.android.support:design:26.1.0'
-    provided 'com.android.support:support-annotations:27.0.2'
+    implementation fileTree(dir: 'libs', include: ['*.jar'])
+    testImplementation 'junit:junit:4.12'
+    implementation 'com.android.support:appcompat-v7:26.1.0'
+    implementation 'online.devliving:mobilevision-pipeline:1.0.7'
+    implementation 'com.google.android.gms:play-services-basement:11.8.0'
+    implementation 'com.google.android.gms:play-services-vision:11.8.0'
+    implementation 'com.android.support:design:26.1.0'
+    implementation 'com.android.support:support-annotations:27.0.2'
 }
 
 def siteUrl = "https://github.com/iamMehedi/MVBarcodeReader"

--- a/mvbarcodereader/build.gradle
+++ b/mvbarcodereader/build.gradle
@@ -1,4 +1,5 @@
 apply plugin: 'com.android.library'
+apply plugin: 'maven'
 
 version = "1.1.3"
 
@@ -23,10 +24,10 @@ android {
 dependencies {
     implementation fileTree(dir: 'libs', include: ['*.jar'])
     testImplementation 'junit:junit:4.12'
-    implementation 'com.android.support:appcompat-v7:27.1.1'
+    compileOnly 'com.android.support:appcompat-v7:27.1.1'
     implementation 'online.devliving:mobilevision-pipeline:1.0.7'
-    implementation 'com.google.android.gms:play-services-basement:15.0.0'
-    implementation 'com.google.android.gms:play-services-vision:15.0.0'
-    implementation 'com.android.support:design:27.1.1'
-    implementation 'com.android.support:support-annotations:27.1.1'
+    compileOnly 'com.google.android.gms:play-services-basement:15.0.0'
+    compileOnly 'com.google.android.gms:play-services-vision:15.0.0'
+    compileOnly 'com.android.support:design:27.1.1'
+    compileOnly 'com.android.support:support-annotations:27.1.1'
 }

--- a/mvbarcodereader/build.gradle
+++ b/mvbarcodereader/build.gradle
@@ -5,12 +5,12 @@ apply plugin: "com.jfrog.bintray"
 version = "1.1.3"
 
 android {
-    compileSdkVersion 26
-    buildToolsVersion "26.0.2"
+    compileSdkVersion 27
+    buildToolsVersion "27.0.3"
 
     defaultConfig {
         minSdkVersion 15
-        targetSdkVersion 26
+        targetSdkVersion 27
         versionCode 19
         versionName version
     }
@@ -25,12 +25,12 @@ android {
 dependencies {
     implementation fileTree(dir: 'libs', include: ['*.jar'])
     testImplementation 'junit:junit:4.12'
-    implementation 'com.android.support:appcompat-v7:26.1.0'
+    implementation 'com.android.support:appcompat-v7:27.1.1'
     implementation 'online.devliving:mobilevision-pipeline:1.0.7'
-    implementation 'com.google.android.gms:play-services-basement:11.8.0'
-    implementation 'com.google.android.gms:play-services-vision:11.8.0'
-    implementation 'com.android.support:design:26.1.0'
-    implementation 'com.android.support:support-annotations:27.0.2'
+    implementation 'com.google.android.gms:play-services-basement:15.0.0'
+    implementation 'com.google.android.gms:play-services-vision:15.0.0'
+    implementation 'com.android.support:design:27.1.1'
+    implementation 'com.android.support:support-annotations:27.1.1'
 }
 
 def siteUrl = "https://github.com/iamMehedi/MVBarcodeReader"

--- a/mvbarcodereader/src/main/java/devliving/online/mvbarcodereader/BarcodeCaptureFragment.java
+++ b/mvbarcodereader/src/main/java/devliving/online/mvbarcodereader/BarcodeCaptureFragment.java
@@ -565,7 +565,9 @@ public class BarcodeCaptureFragment extends Fragment implements View.OnTouchList
          */
         @Override
         public void onScaleEnd(ScaleGestureDetector detector) {
-            mCameraSource.doZoom(detector.getScaleFactor());
+            if(mCameraSource != null){
+                mCameraSource.doZoom(detector.getScaleFactor());
+            }
         }
     }
 

--- a/mvbarcodereader/src/main/java/devliving/online/mvbarcodereader/MVBarcodeScanner.java
+++ b/mvbarcodereader/src/main/java/devliving/online/mvbarcodereader/MVBarcodeScanner.java
@@ -1,8 +1,10 @@
 package devliving.online.mvbarcodereader;
 
 import android.app.Activity;
+import android.content.Context;
 import android.content.Intent;
 import android.support.annotation.IntDef;
+import android.support.v4.app.Fragment;
 
 import com.google.android.gms.vision.barcode.Barcode;
 
@@ -28,11 +30,15 @@ public class MVBarcodeScanner {
     }
 
     public void launchScanner(Activity activity, int requestCode) {
-        activity.startActivityForResult(getScannerIntent(), requestCode);
+        activity.startActivityForResult(getScannerIntent(activity), requestCode);
     }
 
-    public Intent getScannerIntent() {
-        Intent i = new Intent(activity, BarcodeCaptureActivity.class);
+    public void launchScanner(Fragment fragment, int requestCode) {
+        fragment.startActivityForResult(getScannerIntent(fragment.getContext()), requestCode);
+    }
+
+    public Intent getScannerIntent(Context context) {
+        Intent i = new Intent(context, BarcodeCaptureActivity.class);
         if (mMode != null) i.putExtra(SCANNING_MODE, mMode);
         if (mFormats != null) i.putExtra(BARCODE_FORMATS, mFormats);
         return i;

--- a/mvbarcodereader/src/main/java/devliving/online/mvbarcodereader/MVBarcodeScanner.java
+++ b/mvbarcodereader/src/main/java/devliving/online/mvbarcodereader/MVBarcodeScanner.java
@@ -28,11 +28,14 @@ public class MVBarcodeScanner {
     }
 
     public void launchScanner(Activity activity, int requestCode) {
+        activity.startActivityForResult(getScannerIntent(), requestCode);
+    }
+
+    public Intent getScannerIntent() {
         Intent i = new Intent(activity, BarcodeCaptureActivity.class);
         if (mMode != null) i.putExtra(SCANNING_MODE, mMode);
         if (mFormats != null) i.putExtra(BARCODE_FORMATS, mFormats);
-
-        activity.startActivityForResult(i, requestCode);
+        return i;
     }
 
     public static class Builder {

--- a/settings.gradle
+++ b/settings.gradle
@@ -1,1 +1,1 @@
-include ':app', ':mvbarcodereader'
+include ':mvbarcodereader'

--- a/settings.gradle
+++ b/settings.gradle
@@ -1,1 +1,1 @@
-include ':mvbarcodereader'
+include ':app', ':mvbarcodereader'


### PR DESCRIPTION
I wanted to use the RxActivityResult library to launch the barcode request with Rx. This required access to the barcode Intent. I created a method to get the Intent, as well as a new method that allows the Intent to be launched using a Fragment, instead of an Activity.

Also, I updated the Gradle dependencies to use Implementation and CompileOnly, instead of Compile and Provided, respectively. Also updated the Gradle version, Play Services version, etc. These updates also fixed compatibility with the JitPack build system.

This pull request includes the commit by @kksingla to update BarcodeCaptureFragment.java.